### PR TITLE
Update upstream to 6.31.1

### DIFF
--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -713,6 +713,11 @@ export interface IncludeOptions extends Filterable<any>, Projectable, Paranoid {
    * Use sub queries. This should only be used if you know for sure the query does not result in a cartesian product.
    */
   subQuery?: boolean;
+
+  /**
+   * MySQL and MariaDB only.
+   */
+  indexHints?: IndexHint[];
 }
 
 type OrderItemAssociation = Association | ModelStatic<Model> | { model: ModelStatic<Model>; as: string } | string

--- a/test/unit/sql/generateJoin.test.js
+++ b/test/unit/sql/generateJoin.test.js
@@ -3,6 +3,7 @@
 const Support = require('../support'),
   DataTypes = require('sequelize/lib/data-types'),
   Sequelize = require('sequelize/lib/sequelize'),
+  IndexHints = require('sequelize/lib/sequelize'),
   util = require('util'),
   _ = require('lodash'),
   expectsql = Support.expectsql,
@@ -32,7 +33,10 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
           }
         );
 
-        return expectsql(`${join.join} ${join.body} ON ${join.condition}`, expectation);
+        return expectsql(
+          `${join.join} ${join.body} ${join.indexHints ? `${join.indexHints} ` : ''}ON ${join.condition}`,
+          expectation
+        );
       });
     };
 
@@ -120,6 +124,58 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         default: 'INNER JOIN [company] AS [Company] ON [User].[company_id] = [Company].[id] OR [Company].[public] = true',
         sqlite: 'INNER JOIN `company` AS `Company` ON `User`.`company_id` = `Company`.`id` OR `Company`.`public` = 1',
         oracle: 'INNER JOIN "company" "Company" ON "User"."company_id" = "Company"."id" OR "Company"."public" = \'1\'',
+        mssql: 'INNER JOIN [company] AS [Company] ON [User].[company_id] = [Company].[id] OR [Company].[public] = 1'
+      }
+    );
+
+    testsql(
+      'include[0]',
+      {
+        model: User,
+        include: [
+          {
+            association: User.Company,
+            where: { public: true },
+            or: true,
+            indexHints: [
+              { type: IndexHints.USE, values: ['index_project_on_name', 'index_project_on_name_and_foo'] }
+            ]
+          }
+        ]
+      },
+      {
+        default: 'INNER JOIN [company] AS [Company] ON [User].[company_id] = [Company].[id] OR [Company].[public] = true',
+        mysql: 'INNER JOIN `company` AS `Company` USE INDEX (`index_project_on_name`,`index_project_on_name_and_foo`) ON `User`.`company_id` = `Company`.`id` OR `Company`.`public` = true',
+        mariadb: 'INNER JOIN `company` AS `Company` USE INDEX (`index_project_on_name`,`index_project_on_name_and_foo`) ON `User`.`company_id` = `Company`.`id` OR `Company`.`public` = true',
+        snowflake: 'INNER JOIN "company" AS "Company" USE INDEX ("index_project_on_name","index_project_on_name_and_foo") ON "User"."company_id" = "Company"."id" OR "Company"."public" = true',
+        ibmi: 'INNER JOIN "company" AS "Company" ON "User"."company_id" = "Company"."id" OR "Company"."public" = 1',
+        sqlite: 'INNER JOIN `company` AS `Company` ON `User`.`company_id` = `Company`.`id` OR `Company`.`public` = 1',
+        mssql: 'INNER JOIN [company] AS [Company] ON [User].[company_id] = [Company].[id] OR [Company].[public] = 1'
+      }
+    );
+
+    testsql(
+      'include[0]',
+      {
+        model: User,
+        include: [
+          {
+            association: User.Company,
+            where: { public: true },
+            or: true,
+            indexHints: [
+              { type: IndexHints.USE, values: ['index_project_on_name', 'index_project_on_name_and_foo'] }
+            ]
+          }
+        ]
+      },
+      {
+        default: 'INNER JOIN [company] AS [Company] ON [User].[company_id] = [Company].[id] OR [Company].[public] = true',
+        mysql: 'INNER JOIN `company` AS `Company` USE INDEX (`index_project_on_name`,`index_project_on_name_and_foo`) ON `User`.`company_id` = `Company`.`id` OR `Company`.`public` = true',
+        mariadb: 'INNER JOIN `company` AS `Company` USE INDEX (`index_project_on_name`,`index_project_on_name_and_foo`) ON `User`.`company_id` = `Company`.`id` OR `Company`.`public` = true',
+        snowflake: 'INNER JOIN "company" AS "Company" USE INDEX ("index_project_on_name","index_project_on_name_and_foo") ON "User"."company_id" = "Company"."id" OR "Company"."public" = true',
+        ibmi: 'INNER JOIN "company" AS "Company" ON "User"."company_id" = "Company"."id" OR "Company"."public" = 1',
+        sqlite: 'INNER JOIN `company` AS `Company` ON `User`.`company_id` = `Company`.`id` OR `Company`.`public` = 1',
         mssql: 'INNER JOIN [company] AS [Company] ON [User].[company_id] = [Company].[id] OR [Company].[public] = 1'
       }
     );

--- a/test/unit/sql/index-hints-fragment.test.js
+++ b/test/unit/sql/index-hints-fragment.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const Support   = require('../support');
+
+const current   = Support.sequelize;
+const expectsql = Support.expectsql;
+const sql = current.dialect.queryGenerator;
+const { IndexHints } = require('@sequelize/core');
+
+if (current.dialect.supports.indexHints) {
+  describe(Support.getTestDialectTeaser('SQL'), () => {
+    describe('indexHintsFragment', () => {
+      it('correctly formats the index hints', () => {
+        expectsql(sql.indexHintsFragment([{ type: IndexHints.USE, values: ['index_project_on_name'] }]), {
+          default: 'USE INDEX (`index_project_on_name`)',
+          snowflake: 'USE INDEX ("index_project_on_name")'
+        });
+        expectsql(sql.indexHintsFragment([{ type: IndexHints.FORCE, values: ['index_project_on_name'] }]), {
+          default: 'FORCE INDEX (`index_project_on_name`)',
+          snowflake: 'FORCE INDEX ("index_project_on_name")'
+        });
+        expectsql(sql.indexHintsFragment([{ type: IndexHints.IGNORE, values: ['index_project_on_name'] }]), {
+          default: 'IGNORE INDEX (`index_project_on_name`)',
+          snowflake: 'IGNORE INDEX ("index_project_on_name")'
+        });
+        expectsql(sql.indexHintsFragment([{ type: IndexHints.USE, values: ['index_project_on_name', 'index_project_on_name_and_foo'] }]), {
+          default: 'USE INDEX (`index_project_on_name`,`index_project_on_name_and_foo`)',
+          snowflake: 'USE INDEX ("index_project_on_name","index_project_on_name_and_foo")'
+        });
+        expectsql(sql.indexHintsFragment([{ indexHints: [{ type: 'FOO', values: ['index_project_on_name'] }] }]), {
+          default: ''
+        });
+        expectsql(sql.indexHintsFragment([{ indexHints: [{ type: 'FOO', values: ['index_project_on_name'] }] }, { indexHints: [{ type: 'BAR', values: ['index_project_on_name'] }] }]), {
+          default: ''
+        });
+      });
+    });
+  });
+}


### PR DESCRIPTION
# Motivation
- We're updating Yarn to the latest version so that we can use the new package cache feature. In order to do so, each package must be buildable on our machines. This PR simply updates our upstream version so that we can build this package on our M1 based MacBooks
- ~~Note: I originally tried to update to v6.31.1, but Sequelize added support for OracleDB in v6.22.0, which doesn't have any ARM binaries, and therefore refuses to build on my machine. There's most likely a way around this (as installing the upstream package works fine), but I'm unsure what that workaround is~~
  - Turns out this was a packaging issue on our end. We're not supposed to package `yarn.lock` (among other things)

# Changes
- Update upstream to 6.31.1 (effectively a rebase)
  - Hard reset `wanderlog` branch to `v6.31.1` tag
  - Cherry picked Tuyet's commit for index hints (no merge conflicts)

# Testing
None yet.